### PR TITLE
README.md: Change slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DuckDuckGo (Core) [![Build Status](https://travis-ci.org/duckduckgo/duckduckgo.png?branch=master)](https://travis-ci.org/duckduckgo/duckduckgo)
 
-Join us on Slack! [Request invite](mailto:QuackSlack@duckduckgo.com?subject=AddMe)
+Join us on Slack! [Request invite](https://quackslack.herokuapp.com/)
 
 This repository contains the core code responsible for triggering and handling the DuckDuckHack Instant Answers. It is the base of the DuckDuckHack Instant Answer infrastructure.  
 


### PR DESCRIPTION
Update slack email invite link to self-hosted invite link

Fixes https://github.com/duckduckgo/duckduckgo/issues/227